### PR TITLE
Update 1Password mobile price (it's not free)

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@
             },
             {
               name: 'iOS & Android apps',
-              price: 'Free',
+              price: 'Free on iOS (pro features $5.99), $9.99 on Android',
             }
           ],
           browser_plugins: [


### PR DESCRIPTION
1Password isn't free on mobile, except for iOS where most of its features are available for free as part of a freemium model.
