### PR TITLE
Again, 1Password for Android is not free.

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,7 +135,7 @@
             },
             {
               name: 'Android app',
-              price: 'Free (Pro features $9.99)'
+              price: '$9.99'
             }
           ],
           browser_plugins: [


### PR DESCRIPTION
I've already changed this in PR #1, but it got changed back for some reason.

1Password for Android is based on a "free trial" model, not a freemium model -- despite AgileBits claiming so. From the [FAQ](https://support.1password.com/premium-features-faq/#what-do-i-get-for-free-in-1password-for-android-): (emphasis mine)

> ## What do I get for free in 1Password for Android?
> 
> When you download 1Password from the Google Play Store, you can use it absolutely free and unrestricted for 30 days. This gives you the opportunity to try all its features and really get a feel for the application.
> 
> Your free trial begins when you first open 1Password on your Android device. After 30 days, **its Reader functionality will remain free.**

After 30 days, the app reverts to **read-only mode**. You can still modify existing items, however, but you can't add anything and there is no "item quota" -- if you delete an entry, you can't add one in place of it. It's a classic software trial model.
